### PR TITLE
Improve language mapping and logging for dubs/subs handling

### DIFF
--- a/app/appdata/modules/MDNX_API.py
+++ b/app/appdata/modules/MDNX_API.py
@@ -220,7 +220,6 @@ class MDNX_API:
 
         tmp_cmd = [self.mdnx_path, "--service", self.mdnx_service, "--srz", series_id]
         result = subprocess.run(tmp_cmd, capture_output=True, text=True, encoding="utf-8")
-        logger.info(f"[MDNX_API] Console output for start_monitor process:\n{result.stdout}")
 
         self.process_console_output(result.stdout)
 
@@ -240,7 +239,6 @@ class MDNX_API:
 
         tmp_cmd = [self.mdnx_path, "--service", self.mdnx_service, "--srz", series_id]
         result = subprocess.run(tmp_cmd, capture_output=True, text=True, encoding="utf-8")
-        logger.info(f"[MDNX_API] Console output for update_monitor process:\n{result.stdout}")
 
         self.process_console_output(result.stdout)
 


### PR DESCRIPTION
This is experimental. The new code in probe_streams() tries to map things like "Chinese (Mainland China)" to "zho" when doing the ffprobe. ffprobe returns "Chinese (Mainland China)" as "chi", which is incorrect for multi-download-nx. Have no idea how well this is going to work for other langs...