### PR TITLE
Removing the special/PV episode downloading feature

### DIFF
--- a/app/appdata/modules/MainLoop.py
+++ b/app/appdata/modules/MainLoop.py
@@ -51,22 +51,11 @@ class MainLoop:
             refresh_queue(self.mdnx_api)
             current_queue = self.mdnx_api.queue_manager.output()
 
-
             # download any missing / not yet downloaded episodes
             logger.info("[MainLoop] Checking for episodes to download.")
             for series_id, season_key, episode_key, season_info, episode_info in iter_episodes(current_queue):
 
-                # Skip special episode keys (for example, if the episode key starts with "S")
-                if episode_key.startswith("S") and config["app"]["DOWNLOAD_SPECIAL_EPISODES"] == False:
-                    logger.info(f"[MainLoop] Skipping special episode {episode_key} because DOWNLOAD_SPECIAL_EPISODES is False.")
-                    continue
-
-                # Skip PV episodes
-                if episode_info["episode_name"].lower().startswith("pv"):
-                    logger.info(f"[MainLoop] Skipping PV episode {episode_key}")
-                    continue
-
-                # Should episode be downloaded logic
+                # Should episode be downloaded?
                 if episode_info["episode_downloaded"]:
                     logger.info(f"[MainLoop] Episode {episode_info['episode_number']} ({episode_info['episode_name']}) 'episode_downloaded' status is True. Skipping download.")
                     continue
@@ -173,6 +162,7 @@ class MainLoop:
                     )
 
                     if skip_download:
+                        logger.info(f"[MainLoop] Skipping download for {os.path.basename(file_path)} as all required dubs and subs are present.")
                         continue
 
                     if self.mdnx_api.download_episode(series_id, season_info["season_id"], episode_info["episode_number_download"]):

--- a/app/appdata/modules/Vars.py
+++ b/app/appdata/modules/Vars.py
@@ -76,7 +76,8 @@ for vals in LANG_MAP.values():
 
 CODE_TO_LOCALE = {}
 for name, vals in LANG_MAP.items():
-    code, loc = vals[0].lower(), vals[1].lower()
+    code = vals[0].lower()
+    loc = vals[1].lower()
     CODE_TO_LOCALE[code] = loc
 
 # Set up logging


### PR DESCRIPTION
I have decided to remove this feature for 2 reasons:
1. When the special episode is downloaded, i have no way to confirm what S00EXX is supposed to be. If it downloads as S00E01, but TheTVDB or TMDB says that episode is actually S00E03, i have no way to confirm that and rename that correctly, so plex/jellyfin would show the wrong metadata or worse, not show the episode at all.

2. Because of my season numbering fix (making Season 61 to Season 1 for example), some anime has one season for storing the movie, which is a special episode. For example, is a series has 2 seasons and a movie, the `queue.json` would have S1 as season 1, S2 as the movie and S3 and season 2 depending on what console output was given by multi-download-nx. Again, wrong naming and wrong metadata.

I will look into bringing this feature back. However, i want to focus on automatically downloading the new normal episodes in a solid way (and them actually showing up correctly) before adding some nice features.