### PR TITLE
Add fallback dub selection

### DIFF
--- a/app/appdata/modules/MainLoop.py
+++ b/app/appdata/modules/MainLoop.py
@@ -6,7 +6,7 @@ import threading
 from .FileHandler import FileHandler
 from .Vars import logger, config
 from .Vars import TEMP_DIR, DATA_DIR
-from .Vars import get_episode_file_path, iter_episodes, log_manager, refresh_queue, probe_streams
+from .Vars import get_episode_file_path, iter_episodes, log_manager, refresh_queue, probe_streams, select_dubs
 
 # Only for syntax highlighting in VSCode - remove in prod
 # from .MDNX_API import MDNX_API
@@ -72,7 +72,10 @@ class MainLoop:
                         continue
                     else:
                         logger.info(f"[MainLoop] Episode not found at {file_path} and 'episode_downloaded' status is False. Initiating download.")
-                        download_successful = self.mdnx_api.download_episode(series_id, season_info["season_id"], episode_info["episode_number_download"])
+
+                        dub_override = select_dubs(episode_info)
+
+                        download_successful = self.mdnx_api.download_episode(series_id, season_info["season_id"], episode_info["episode_number_download"], dub_override)
                         if download_successful:
                             logger.info(f"[MainLoop] Episode downloaded successfully.")
 
@@ -165,7 +168,9 @@ class MainLoop:
                         logger.info(f"[MainLoop] Skipping download for {os.path.basename(file_path)} as all required dubs and subs are present.")
                         continue
 
-                    if self.mdnx_api.download_episode(series_id, season_info["season_id"], episode_info["episode_number_download"]):
+                    dub_override = select_dubs(episode_info)
+
+                    if self.mdnx_api.download_episode(series_id, season_info["season_id"], episode_info["episode_number_download"], dub_override):
                         temp_path = os.path.join(TEMP_DIR, config["mdnx"]["cli-defaults"]["fileName"] + ".mkv")
                         if self.file_handler.transfer(temp_path, file_path, overwrite=True):
                             logger.info("[MainLoop] Transfer complete.")

--- a/appdata/config/config.json
+++ b/appdata/config/config.json
@@ -7,6 +7,7 @@
         "DATA_DIR": "/data",
         "CR_USERNAME": "",
         "CR_PASSWORD": "",
+        "BACKUP_DUBS": ["zho"],
         "FOLDER_STRUCTURE": "${seriesTitle}/S${season}/${seriesTitle} - S${seasonPadded}E${episodePadded}",
         "DOWNLOAD_SPECIAL_EPISODES": false,
         "SPECIAL_EPISODES_FOLDER_NAME": "Special",


### PR DESCRIPTION
Introduces a select_dubs function to choose appropriate dubs based on user preferences and available options. Updates MainLoop and MDNX_API to use dub overrides when downloading episodes, and adds BACKUP_DUBS to the config for fallback language selection. Ensures episodes are skipped if no dubs are available.

This is great when you have `mdnx.dubLang` set to your wanted dubs, like `"jpn", "eng"` but then there is an anime that only has a dub in Chinese (for example, Lord of Mysteries). In that case, the episode wouldn't be downloaded.
What this allows you to do is set `mdnx.dubLang` to what you want all your episodes to have, but set `app.BACKUP_DUBS` to whatever you think you may encounter in the future that you dont really want every anime having, but still want the ability to download the episode with those dubs. And if the anime you are trying to download has a dub not specified in either `mdnx.dubLang` or `app.BACKUP_DUBS`, it will download the first available dub it finds in the `queue.json` for that episode.