### PR TITLE
Update multi-download-nx

### DIFF
--- a/app/appdata/bin/versions.txt
+++ b/app/appdata/bin/versions.txt
@@ -1,2 +1,2 @@
 Bento4-SDK.zip=1.6.0-641
-mdnx.zip=5.5.0
+mdnx.zip=5.5.1


### PR DESCRIPTION
### Dependency updates:
Updated multi-download-nx from [5.5.0 -> 5.5.1](https://github.com/anidl/multi-downloader-nx/releases/tag/v5.5.1)