### PR TITLE
Add --tsd option in executed download command if desired

### DIFF
--- a/app/appdata/modules/MDNX_API.py
+++ b/app/appdata/modules/MDNX_API.py
@@ -54,6 +54,12 @@ class MDNX_API:
         else:
             logger.info("[MDNX_API] API test skipped by user.")
 
+        # Set --tsd param if user wants to
+        self.REMOVE_ALL_ACTIVE_STREAMS = False
+        if config["app"]["REMOVE_ALL_ACTIVE_STREAMS"] == True:
+            self.REMOVE_ALL_ACTIVE_STREAMS = True
+            logger.info("[MDNX_API] User requested to remove all active streams when downloading. Setting --tsd parameter to true.")
+
     def process_console_output(self, output: str, add2queue: bool = True):
         logger.debug("[MDNX_API] Processing console output...")
         tmp_dict = {}
@@ -299,6 +305,9 @@ class MDNX_API:
         if dub_override:
             tmp_cmd += ["--dubLang", *dub_override]
             logger.info(f"[MDNX_API] Using dubLang override: {' '.join(dub_override)}")
+
+        if self.REMOVE_ALL_ACTIVE_STREAMS:
+            tmp_cmd += ["--tsd", "true"]
 
         if self.stdbuf_exists:
             cmd = ["stdbuf", "-oL", "-eL", *tmp_cmd]

--- a/appdata/config/config.json
+++ b/appdata/config/config.json
@@ -18,6 +18,7 @@
         "CR_FORCE_REAUTH": false,
         "CR_SKIP_API_TEST": false,
         "NOTIFICATION_PREFERENCE": "none",
+        "REMOVE_ALL_ACTIVE_STREAMS": false,
         "LOG_LEVEL": "info"
     },
     "mdnx": {


### PR DESCRIPTION
When making the download command, it will add the `--tsd` parameter depending on if you have `app.REMOVE_ALL_ACTIVE_STREAMS` set to `true`