### PR TITLE
Separate docker image

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -7,16 +7,11 @@ permissions:
   contents: read
   packages: write
 
-env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/mdnx-auto-dl-base
-
 jobs:
   build-base:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -25,10 +20,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/hypernylium/mdnx-auto-dl-base
+          tags: |
+            type=raw,value=latest
+
       - name: Build & push base image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.base
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
+          tags:   ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,0 +1,34 @@
+name: Create base image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/mdnx-auto-dl-base
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push base image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.base
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,4 +1,4 @@
-name: Create base image
+name: Build & push base image
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ permissions:
   packages: write
 
 jobs:
-  build-base:
+  build-base-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,47 @@
+name: Build & push test image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. 0.0.1)"
+        required: true
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            ${{ format('type=raw,value={0}', inputs.version) }}
+
+      - name: Pull base image
+        run: docker pull ghcr.io/hypernylium/mdnx-auto-dl-base:latest || true
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags:   ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 jobs:
-  build:
+  build-active-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Create active image
+name: Build & push active image
 
 on:
   workflow_dispatch:
@@ -8,15 +8,16 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -33,6 +34,9 @@ jobs:
           tags: |
             type=raw,value=latest
             ${{ inputs.version != '' && format('type=raw,value={0}', inputs.version) || '' }}
+
+      - name: Pull base image
+        run: docker pull ghcr.io/hypernylium/mdnx-auto-dl-base:latest || true
 
       - name: Build & push image
         id: build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build & publish Docker image
+name: Create active image
 
 on:
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,12 @@
-FROM python:3.11-slim
-
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        curl \
-        ca-certificates \
-        iputils-ping \
-        ffmpeg \
-        mkvtoolnix \
-        jq \
-        gosu \
-        unzip && \
-    rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/hypernylium/mdnx-auto-dl/base:latest
 
 WORKDIR /app
 
 COPY app/ .
 
-# We will make a non-root user in entrypoint.sh
 USER root
 
 # Convert Windows line-endings (CRLF) to LF
-RUN sed -i 's/\r$//' /app/entrypoint.sh \
-    && chmod +x /app/entrypoint.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        iputils-ping \
+        ffmpeg \
+        mkvtoolnix \
+        jq \
+        gosu \
+        unzip && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I have seperated the docker image into 2 files.

- `Dockerfile`: This is where the code will actually go/live. When i new release happens, this will be the image that will be built.
-  `Dockerfile.base`: This containers all the non-moving/stale parts like apt, updates, etc. This will not be updated as much.