### PR TITLE
Merge beta to master branch

### DIFF
--- a/app/appdata/bin/versions.txt
+++ b/app/appdata/bin/versions.txt
@@ -1,2 +1,2 @@
 Bento4-SDK.zip=1.6.0-641
-mdnx.zip=5.5.2
+mdnx.zip=5.5.3

--- a/app/appdata/modules/MDNX_API.py
+++ b/app/appdata/modules/MDNX_API.py
@@ -54,12 +54,6 @@ class MDNX_API:
         else:
             logger.info("[MDNX_API] API test skipped by user.")
 
-        # Set --tsd param if user wants to
-        self.REMOVE_ALL_ACTIVE_STREAMS = False
-        if config["app"]["REMOVE_ALL_ACTIVE_STREAMS"] == True:
-            self.REMOVE_ALL_ACTIVE_STREAMS = True
-            logger.info("[MDNX_API] User requested to remove all active streams when downloading. Setting --tsd parameter to true.")
-
     def process_console_output(self, output: str, add2queue: bool = True):
         logger.debug("[MDNX_API] Processing console output...")
         tmp_dict = {}             # maps series_id to series info
@@ -346,9 +340,6 @@ class MDNX_API:
         if dub_override:
             tmp_cmd += ["--dubLang", *dub_override]
             logger.info(f"[MDNX_API] Using dubLang override: {' '.join(dub_override)}")
-
-        if self.REMOVE_ALL_ACTIVE_STREAMS:
-            tmp_cmd += ["--tsd", "true"]
 
         if self.stdbuf_exists:
             cmd = ["stdbuf", "-oL", "-eL", *tmp_cmd]

--- a/appdata/config/config.json
+++ b/appdata/config/config.json
@@ -18,7 +18,6 @@
         "CR_FORCE_REAUTH": false,
         "CR_SKIP_API_TEST": false,
         "NOTIFICATION_PREFERENCE": "none",
-        "REMOVE_ALL_ACTIVE_STREAMS": false,
         "ONLY_CREATE_QUEUE": false,
         "LOG_LEVEL": "info"
     },
@@ -52,7 +51,8 @@
             "keepAllVideos": false,
             "skipUpdate": true,
             "vstream": "androidtv",
-            "astream": "androidtv"
+            "astream": "androidtv",
+            "tsd": false
         },
         "dir-path": {
             "content": "/app/appdata/temp",

--- a/appdata/config/config.json
+++ b/appdata/config/config.json
@@ -51,8 +51,8 @@
             "dlVideoOnce": false,
             "keepAllVideos": false,
             "skipUpdate": true,
-            "vstream": "samsungtv",
-            "astream": "android"
+            "vstream": "androidtv",
+            "astream": "androidtv"
         },
         "dir-path": {
             "content": "/app/appdata/temp",


### PR DESCRIPTION
## What's Changed

- Updated default `vstream` and `astream` to `androidtv`, as that has the better video.
- Removed the `REMOVE_ALL_ACTIVE_STREAMS` option. The reason why this was added was because even though this option was suppose to be able to be set in `cli-defaults.yml`, it was never honored. It only worked through `--tsd true` from the cli call. After testing, it seems like multi-downloader-nx is honoring the defaults file, so this additional feature is no longer needed. 
If you were using this, set the "tsd" value to "true" in `config.json`.

- Dependency updates:
    - Updated multi-download-nx from [5.5.2 -> 5.5.3](https://github.com/anidl/multi-downloader-nx/releases/tag/v5.5.3)