### PR TITLE
Merge beta to master branch

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -7,6 +7,7 @@ import threading
 # Custom imports
 from appdata.modules.MDNX_API import MDNX_API
 from appdata.modules.MainLoop import MainLoop
+from appdata.modules.MediaServerManager import mediaserver_auth, mediaserver_scan_library
 from appdata.modules.Vars import (
     logger, config,
     MDNX_SERVICE_CR_TOKEN_PATH,
@@ -77,6 +78,24 @@ def app():
     else:
         logger.error(f"[app] Unsupported notification preference: {config['app']['NOTIFICATION_PREFERENCE']}. Supported options are 'ntfy', 'smtp' or 'none'.")
         sys.exit(1)
+
+    server_type = config["app"]["MEDIASERVER_TYPE"]
+
+    if isinstance(server_type, str) and server_type.strip() != "":
+        logger.debug(f"[app] Media server type: {server_type}")
+
+        if not mediaserver_auth():
+            logger.error("[app] Authentication timed out or failed. Check the logs.")
+            sys.exit(1)
+
+        logger.info("[app] User is authenticated. Testing library scan...")
+        if not mediaserver_scan_library():
+            logger.error("[app] Library scan failed. Please check your configuration.")
+            sys.exit(1)
+        else:
+            logger.info("[app] Library scan successful.")
+    else:
+        logger.info("[app] MEDIASERVER_TYPE not set. Skipping media server auth/scan.")
 
     # Start MainLoop
     logger.info("[app] Starting MainLoop...")

--- a/app/appdata/bin/versions.txt
+++ b/app/appdata/bin/versions.txt
@@ -1,2 +1,2 @@
 Bento4-SDK.zip=1.6.0-641
-mdnx.zip=5.5.5
+mdnx.zip=5.5.6

--- a/app/appdata/modules/MainLoop.py
+++ b/app/appdata/modules/MainLoop.py
@@ -3,6 +3,7 @@ import threading
 from datetime import datetime
 
 # Custom imports
+from .MediaServerManager import mediaserver_scan_library
 from .Globals import (
     file_manager, queue_manager
 )
@@ -11,7 +12,6 @@ from .Vars import (
     TEMP_DIR, DATA_DIR,
     get_episode_file_path, iter_episodes, log_manager, probe_streams, select_dubs, format_duration
 )
-from .MediaServerManager import scan_media_server
 
 
 
@@ -361,7 +361,7 @@ class MainLoop:
                 # Trigger media server scan if configured and there are new items in the notifications buffer.
                 if len(self.notifications_buffer) > 0 and self.config["app"]["MEDIASERVER_TYPE"] is not None:
                     logger.info("[MainLoop] Triggering media server scan.")
-                    scan_media_server()
+                    mediaserver_scan_library()
 
                 # Flush notifications buffer if it has items.
                 if self.notifications_buffer:

--- a/app/appdata/modules/MainLoop.py
+++ b/app/appdata/modules/MainLoop.py
@@ -324,7 +324,7 @@ class MainLoop:
                             logger.info(f"[MainLoop] Missing dubs detected for {episode_basename}: {', '.join(effective_missing_dubs)}. Re-downloading episode to acquire missing dubs.")
 
                         if effective_missing_subs:
-                            logger.info(f"[MainLoop] Missing dubs detected for {episode_basename}: {', '.join(effective_missing_subs)}. Re-downloading episode to acquire missing dubs.")
+                            logger.info(f"[MainLoop] Missing dubs detected for {episode_basename}: {', '.join(effective_missing_subs)}. Re-downloading episode to acquire missing subs.")
 
                         dub_override = select_dubs(episode_info)
 

--- a/app/appdata/modules/MediaServerManager.py
+++ b/app/appdata/modules/MediaServerManager.py
@@ -1,72 +1,259 @@
+import sys
+import time
+import uuid
 import requests
+from urllib.parse import urlencode
+
 
 # Custom imports
-from .Vars import logger, config
+from .Vars import (
+    logger, config, 
+    update_app_config, format_duration
+)
+
+# These dont need to be changed, hence they are constants
+PLEX_API_BASE = "https://plex.tv/api/v2"
+PLEX_API_AUTH_URL = "https://app.plex.tv/auth"
+PLEX_PRODUCT_NAME = "mdnx-auto-dl"
+PLEX_PIN_TIMEOUT_SECONDS = 180
+MEDIA_SERVER_INSTANCE = None # holds the PLEX_API or JELLYFIN_API class instance once created
 
 
+class PLEX_API:
+    def __init__(self, config=config) -> None:
+        self.token = config["app"]["MEDIASERVER_TOKEN"]
+        self.server_url = config["app"]["MEDIASERVER_URL"]
+        self.url_override = config["app"]["MEDIASERVER_URL_OVERRIDE"]
 
-def scan_media_server() -> bool:
-    media_server_type = config["app"]["MEDIASERVER_TYPE"]
-    media_server_url = config["app"]["MEDIASERVER_URL"]
-    media_server_token = config["app"]["MEDIASERVER_TOKEN"]
-    media_server_url_override = config["app"]["MEDIASERVER_URL_OVERRIDE"]
+        if self.server_url is None or self.server_url == "":
+            logger.error("[PLEX_API] MEDIASERVER_URL is not set or empty. Please set it in config.json. Exiting...")
+            sys.exit(1)
 
-    if not media_server_url or not media_server_token:
-        logger.info("[MediaServerManager] Media server URL or token not configured. Skipping scan.")
+        if isinstance(self.server_url, str):
+            self.server_url = self.server_url.strip().rstrip("/")
+
+        # Per-process client id (Plex requires a client identifier)
+        self.client_id = str(uuid.uuid4())
+
+        # PIN state
+        self.pin_id = None
+        self.pin_code = None
+        self.pin_started_at = None
+        self.pin_url_logged = False
+
+        logger.info(f"[PLEX_API] PLEX API initialized with: URL: {self.server_url}")
+
+    def wait_for_auth(self, max_wait_seconds: int = 600, poll_interval: float = 1.0) -> bool:
+        if self._verify_token(self.token):
+            return True
+
+        if not (self.pin_id and self.pin_code):
+            self._create_and_log_pin()
+
+        deadline = time.time() + max_wait_seconds
+        while time.time() < deadline:
+            if self._verify_token(self.token):
+                return True
+
+            if self.pin_id and self.pin_code:
+                new_token = self._poll_pin_for_token_once(self.pin_id, self.pin_code)
+                if new_token:
+                    self._store_token(new_token)
+                    self._clear_pin_state()
+                    logger.info("[PLEX_API] Authorization completed. Token stored.")
+                    return True
+
+            if self.pin_started_at and (time.time() - self.pin_started_at > PLEX_PIN_TIMEOUT_SECONDS):
+                logger.info("[PLEX_API] PIN timed out. Generating a new one.")
+                self._clear_pin_state()
+                self._create_and_log_pin()
+
+            time.sleep(poll_interval)
+
+        logger.error(f"[PLEX_API] Authorization timed out after {format_duration(max_wait_seconds)}.")
         return False
 
-    if "plex" in media_server_type.lower():
-        scan_plex(media_server_url, media_server_url_override, media_server_token)
+    def scan_library(self) -> bool:
+        if not self.server_url:
+            logger.info("[PLEX_API] MEDIASERVER_URL not configured. Skipping scan.")
+            return False
 
-    elif "jellyfin" in media_server_type.lower():
-        scan_jellyfin(media_server_url, media_server_url_override, media_server_token)
+        if not self._verify_token(self.token):
+            logger.info("[PLEX_API] No valid token yet.")
+            return False
 
+        if self.url_override:
+            logger.info("[PLEX_API] MEDIASERVER_URL_OVERRIDE is true. Using whatever is in MEDIASERVER_URL for scan endpoint.")
+            url = self.server_url
+        else:
+            logger.info("[PLEX_API] Using standard Plex scan URL for all libraries.")
+            url = f"{self.server_url}/library/sections/all/refresh"
+
+        try:
+            resp = requests.get(url, headers=self._headers(include_token=True), timeout=30)
+            logger.debug(f"[PLEX_API] Scan status={resp.status_code}")
+            resp.raise_for_status()
+            logger.info("[PLEX_API] Scan triggered successfully.")
+            return True
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "unknown"
+            if status == 401:
+                logger.error("[PLEX_API] 401 Unauthorized. Token invalid or lacks permission.")
+            else:
+                logger.error(f"[PLEX_API] HTTP error: {e}")
+        except requests.RequestException as e:
+            logger.error(f"[PLEX_API] Request failed: {e}")
+        return False
+
+    def _headers(self, include_token: bool) -> dict:
+        headers = {
+            "Accept": "application/json",
+            "X-Plex-Product": PLEX_PRODUCT_NAME,
+            "X-Plex-Client-Identifier": self.client_id,
+        }
+        if include_token and self.token:
+            headers["X-Plex-Token"] = self.token
+        return headers
+
+    def _verify_token(self, token) -> bool:
+        if not token:
+            return False
+        try:
+            resp = requests.get(f"{PLEX_API_BASE}/user", headers=self._headers(include_token=True), timeout=10)
+            logger.debug(f"[PLEX_API] Verify token status={resp.status_code}")
+            return resp.status_code == 200
+        except requests.RequestException as e:
+            logger.warning(f"[PLEX_API] Token verify error (network?): {e}")
+            return False
+
+    def _create_and_log_pin(self) -> None:
+        pin_id, code, auth_url = self._start_pin()
+        self.pin_id, self.pin_code, self.pin_started_at = pin_id, code, time.time()
+        if not self.pin_url_logged:
+            logger.info(f"[PLEX_API] Open this URL in a browser to authorize the app:\n{auth_url}")
+            self.pin_url_logged = True
+
+    def _start_pin(self):
+        resp = requests.post(
+            f"{PLEX_API_BASE}/pins",
+            headers=self._headers(include_token=False),
+            data={"strong": "true"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        pin_id, code = data["id"], data["code"]
+        auth_url = PLEX_API_AUTH_URL + "#?" + urlencode(
+            {
+                "clientID": self.client_id,
+                "code": code,
+                "context[device][product]": PLEX_PRODUCT_NAME,
+            }
+        )
+        return pin_id, code, auth_url
+
+    def _poll_pin_for_token_once(self, pin_id, code):
+        try:
+            resp = requests.get(
+                f"{PLEX_API_BASE}/pins/{pin_id}",
+                headers=self._headers(include_token=False),
+                params={"code": code},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json().get("authToken")
+        except requests.RequestException as e:
+            logger.debug(f"[PLEX_API] PIN poll error: {e}")
+            return None
+
+    def _store_token(self, token) -> None:
+        ok = update_app_config("MEDIASERVER_TOKEN", token)
+        if not ok:
+            logger.error("[PLEX_API] Failed to persist MEDIASERVER_TOKEN to config.")
+        self.token = token
+
+    def _clear_pin_state(self) -> None:
+        self.pin_id = None
+        self.pin_code = None
+        self.pin_started_at = None
+        self.pin_url_logged = False
+
+
+class JELLYFIN_API:
+    def __init__(self, config=config) -> None:
+        raw_url = config["app"].get("MEDIASERVER_URL")
+        self.server_url = raw_url.rstrip("/") if isinstance(raw_url, str) and raw_url.strip() else None
+        self.api_key = config["app"].get("MEDIASERVER_TOKEN")
+
+        if self.server_url is None or self.server_url == "":
+            logger.error("[JELLYFIN_API] MEDIASERVER_URL is not set or empty. Please set it in config.json. Exiting...")
+            sys.exit(1)
+        if self.api_key is None or self.api_key == "":
+            logger.error("[JELLYFIN_API] MEDIASERVER_TOKEN (API key) is not set or empty. Please set it in config.json. Exiting...")
+            sys.exit(1)
+
+        logger.info(f"[JELLYFIN_API] Initialized (URL: {self.server_url})")
+
+    def scan_library(self) -> bool:
+        if not self.server_url:
+            logger.info("[JELLYFIN_API] MEDIASERVER_URL not configured. Skipping scan.")
+            return False
+
+        if not self.api_key:
+            logger.info("[JELLYFIN_API] MEDIASERVER_TOKEN (API key) not configured. Skipping scan.")
+            return False
+
+        url = f"{self.server_url}/Library/Refresh"
+        try:
+            resp = requests.post(url, params={"api_key": self.api_key}, timeout=30)
+            logger.debug(f"[JELLYFIN_API] Scan URL: {resp.url}")
+            resp.raise_for_status()
+            logger.debug(f"[JELLYFIN_API] Response: {resp.text}")
+            logger.info("[JELLYFIN_API] Scan triggered successfully.")
+            return True
+        except requests.RequestException as e:
+            logger.error(f"[JELLYFIN_API] Error triggering scan: {e}")
+            return False
+
+
+
+def _get_media_server():
+    global MEDIA_SERVER_INSTANCE
+
+    if MEDIA_SERVER_INSTANCE is not None:
+        return MEDIA_SERVER_INSTANCE
+
+    server_type = config["app"]["MEDIASERVER_TYPE"]
+
+    # No media server configured in config.json
+    if server_type is None:
+        return None
+
+    if server_type == "plex":
+        MEDIA_SERVER_INSTANCE = PLEX_API(config=config)
+    elif server_type == "jellyfin":
+        MEDIA_SERVER_INSTANCE = JELLYFIN_API(config=config)
+    elif server_type == "":
+        logger.error("[MediaServerManager] MEDIASERVER_TYPE is not set. Please set it to 'plex' or 'jellyfin' in config.json. Exiting...")
+        sys.exit(1)
     else:
-        logger.warning("[MediaServerManager] Unsupported media server type. Please use Plex or Jellyfin.")
-        return False
+        logger.error(f"[MediaServerManager] Unsupported media server type: {server_type}. Supported: 'plex' or 'jellyfin'. Exiting...")
+        sys.exit(1)
 
+    return MEDIA_SERVER_INSTANCE
+
+
+# Functions to call from other modules
+def mediaserver_auth(max_wait_seconds: int = 600, poll_interval: float = 1.0) -> bool:
+    inst = _get_media_server()
+    if inst is None:
+        return False
+    if isinstance(inst, PLEX_API):
+        return inst.wait_for_auth(max_wait_seconds, poll_interval)
     return True
 
-def scan_plex(server_url: str, url_override: bool, plex_token: str) -> bool:
-    server_url = server_url.rstrip('/')
-
-    if url_override:
-        url = server_url
-    else:
-        url = f"{server_url}/library/sections/all/refresh"
-
-    params = {"X-Plex-Token": plex_token}
-
-    try:
-        response = requests.get(url, params=params, timeout=30)
-        logger.debug(f"[MediaServerManager] Plex scan URL: {response.url}")
-        response.raise_for_status()
-        logger.debug(f"[MediaServerManager] Plex scan response: {response.text}")
-        logger.info("[MediaServerManager] Plex scan triggered successfully.")
-        return True
-    except requests.RequestException as e:
-        logger.error(f"Error triggering Plex scan: {e}")
-
-    return False
-
-def scan_jellyfin(server_url: str, url_override: bool, api_key: str) -> bool:
-    server_url = server_url.rstrip('/')
-
-    if url_override:
-        url = server_url
-    else:
-        url = f"{server_url}/Library/Refresh"
-
-    params = {"api_key": api_key}
-
-    try:
-        response = requests.post(url, params=params, timeout=30)
-        logger.debug(f"[MediaServerManager] Jellyfin scan URL: {response.url}")
-        response.raise_for_status()
-        logger.debug(f"[MediaServerManager] Jellyfin scan response: {response.text}")
-        logger.info("[MediaServerManager] Jellyfin scan triggered successfully.")
-        return True
-    except requests.RequestException as e:
-        logger.error(f"Error triggering Jellyfin scan: {e}")
-
-    return False
+def mediaserver_scan_library() -> bool:
+    inst = _get_media_server()
+    if inst is None:
+        return False
+    return inst.scan_library()

--- a/appdata/config/config.json
+++ b/appdata/config/config.json
@@ -3,7 +3,9 @@
     "app": {
         "CR_USERNAME": "",
         "CR_PASSWORD": "",
-        "BACKUP_DUBS": ["zho"],
+        "BACKUP_DUBS": [
+            "zho"
+        ],
         "FOLDER_STRUCTURE": "${seriesTitle}/S${season}/${seriesTitle} - S${seasonPadded}E${episodePadded}",
         "CHECK_MISSING_DUB_SUB": true,
         "CHECK_FOR_UPDATES_INTERVAL": 3600,


### PR DESCRIPTION
> [!CAUTION]
> This version has changes that require manual intervention **IF** you set `MEDIASERVER_TYPE` to `plex`.
> If you are in this group, remove the `MEDIASERVER_TOKEN` variable from `config.json` and do a:
> `docker compose down && docker compose up -d && docker compose logs -f`
> You will find a URL in the logs that you have to auth with in order to use the Plex API.
> If you need more explanation, refer to the docs.

# What's Changed

## Fixes

- Fixed the `update_app_config` saving the JSON without preserving the formatting/order of variables.
  It wasn't destructive or anything, just after using it, your `config.json`'s formating/order of variables would be all over the place.

- Fixed Plex auth token returning 401 errors after 24 hours.
  I misunderstood how the X-PLEX-TOKEN in the web interface worked. Thought that was a long-lived token but nope, its a 24 hour ish token that expires, leading to the scan library function failing to send a GET request and returning a 401 error. This has been fixed, but requires you to manually auth with Plex though a URL. This URL will be displayed in the console on first boot and will have a 10 minute timeout. Once auth is complete, you will not need to do it again (unless you go into your Authorized Devices tab and delete the session titled "mdnx-auto-dl")

## Dependencies:
- Updated multi-download-nx from [5.5.5 -> 5.5.6](https://github.com/anidl/multi-downloader-nx/releases/tag/v5.5.6)
 
**Full Changelog**: https://github.com/HyperNylium/mdnx-auto-dl/compare/1.4.1...1.5.0