### PR TITLE
Fix crunchy parser

### DIFF
--- a/app/appdata/modules/CR_MDNX_API.py
+++ b/app/appdata/modules/CR_MDNX_API.py
@@ -64,19 +64,19 @@ class CR_MDNX_API:
         logger.debug("[CR_MDNX_API] Processing console output...")
         tmp_dict = {}             # maps series_id to series info
         episode_counters = {}     # maps season key ("S1", "S2", etc) to episode counter
-        season_num_map = {}       # CR numeric label -> our mapped number (first occurrence wins)
-        season_id_to_key = {}     # season_id -> "S{n}" based on order of appearance
+        season_num_map = {}       # we keep the first numeric label we see as a hint for fallback resolution
+        season_id_to_key = {}     # we map season_id to "S{n}" in order of appearance to avoid duplicate label collisions
         season_order = 0          # running index of seasons as they appear
         current_series_id = None
         active_season_key = None
         active_episode_key = None  # holds the current episode key like "E1"
-        name_to_season_key = {}   # map normalized season_name to season_key ("S1", "S2", etc) so we can resolve mismatched numbers by name
+        name_to_season_key = {}   # map normalized season_name to season_key so episodes can resolve by name first
 
-        # Staging for the currently parsed episode
-        # committed when the next episode starts or at the end.
+        # we stage an episode because its dubs/subs lines arrive after the [E..] line
         staged_episode = None  # dict with: series_id, season_key, ep_key, episode_number_clean, episode_number_download, episode_title_clean, available_subs, available_dubs
 
         def _commit_staged():
+            # we need to flush the staged episode into tmp_dict when context changes or at the end
             nonlocal staged_episode
             if not staged_episode:
                 return
@@ -84,6 +84,7 @@ class CR_MDNX_API:
             s_key = staged_episode["season_key"]
             e_key = staged_episode["ep_key"]
 
+            # create a shell season if an episode appeared before its header
             if s_key not in tmp_dict[s_id]["seasons"]:
                 tmp_dict[s_id]["seasons"][s_key] = {
                     "season_id": None,
@@ -92,6 +93,7 @@ class CR_MDNX_API:
                     "episodes": {}
                 }
 
+            # write the staged episode
             tmp_dict[s_id]["seasons"][s_key]["episodes"][e_key] = {
                 "episode_number": staged_episode["episode_number_clean"],
                 "episode_number_download": staged_episode["episode_number_download"],
@@ -110,17 +112,18 @@ class CR_MDNX_API:
             if not line:
                 continue
 
-            # Check for series information.
+            # series header like "[Z:...] <name> (Seasons: X, EPs: Y)"
             match = self.series_pattern.match(line)
             if match:
-                # before switching series, commit any staged episode
+                # we commit any staged episode before switching series
                 _commit_staged()
 
                 info = match.groupdict()
 
-                # sanitise illegal path characters
+                # sanitize because series_name may be used in filesystem paths
                 info["series_name"] = sanitize(info["series_name"])
 
+                # reset per-series state
                 current_series_id = info["series_id"]
                 tmp_dict[current_series_id] = {"series": info, "seasons": {}}
                 season_num_map.clear()
@@ -132,21 +135,22 @@ class CR_MDNX_API:
                 name_to_season_key.clear()
                 continue
 
-            # Check for season information.
+            # season header like "[S:...] <name> (Season: N)"
             match = self.season_pattern.match(line)
             if match and current_series_id:
-                # commit any staged episode before changing season context
+                # we commit any staged episode before changing season context
                 _commit_staged()
 
                 info = match.groupdict()
                 info["season_name"] = sanitize(info["season_name"])
 
-                # Map seasons strictly by appearance order (or season_id)
+                # we key seasons by season_id and appearance order so duplicate "Season: 1" labels do not collide
                 season_id = info["season_id"]
                 if season_id not in season_id_to_key:
                     season_order += 1
                     mapped_num = season_order
                     season_id_to_key[season_id] = f"S{mapped_num}"
+                    # we remember the first numeric label as a hint for later numeric fallback
                     try:
                         orig_num = int(info["season_number"])
                         season_num_map.setdefault(orig_num, mapped_num)
@@ -159,49 +163,51 @@ class CR_MDNX_API:
                 active_episode_key = None
                 info["season_number"] = str(mapped_num)
 
+                # create the season bucket
                 tmp_dict[current_series_id]["seasons"][season_key] = {
                     **info,
                     "episodes": {}
                 }
                 episode_counters[season_key] = 1
 
+                # we memo the name to resolve episodes by name first
                 name_to_season_key[sanitize(info["season_name"]).lower()] = season_key
                 continue
 
-            # Check for episode information.
+            # episode line like "[E12] [YYYY-MM-DD] <Series Name> - Season N - Episode M"
             match = self.episode_pattern.match(line)
             if match and current_series_id:
-                # committing previous episode (if any) before starting a new one
+                # we commit any previous staged episode before staging a new one
                 _commit_staged()
 
                 ep_info = match.groupdict()
 
-                # skip special episodes (This would include OVAs, "Ex-" episodes, movies (maybe), etc.)
+                # skip specials like "[Sxx]" because we index only normal episodes
                 if ep_info["ep_type"] == "S":
                     continue
 
-                # skip PV / trailer episodes
+                # skip PV or trailer entries that are not full episodes
                 if ep_info["full_episode_name"].lstrip().lower().startswith("pv"):
                     continue
 
-                # Resolve season for this episode.
+                # resolve which mapped season this episode belongs to
                 season_key = None
                 mapped_num = None
 
-                # extract season name
+                # we extract the display name portion before " - Season "
                 full_name_guess = ep_info["full_episode_name"]
-                full_name_guess = re.sub(r'^\[\d{4}-\d{2}-\d{2}\]\s*', '', full_name_guess)
+                full_name_guess = re.sub(r'^\[\d{4}-\d{2}-\d{2}\]\s*', '', full_name_guess)  # strip leading date if present
                 parts_before = full_name_guess.split(' - Season ', 1)
                 season_name_guess = parts_before[0].strip()
 
-                # By season name
+                # try by season name first because names disambiguate duplicate numeric labels
                 guessed_key = name_to_season_key.get(sanitize(season_name_guess).lower())
                 if guessed_key:
                     season_key = guessed_key
                     mapped_num = int(season_key[1:])
                     logger.debug(f"[CR_MDNX_API] Resolved episode season by name '{season_name_guess}' -> {season_key}")
 
-                # By numeric label inside the episode line (fallback)
+                # fallback to the numeric label found in the episode line if name lookup failed
                 if not season_key:
                     season_num = re.search(r'- Season (\d+) -', line)
                     if season_num:
@@ -211,7 +217,7 @@ class CR_MDNX_API:
                             season_key = f"S{mapped_num}"
 
                 if not season_key:
-                    # If we still cant resolve the season, warn and create a shell entry
+                    # if we still cannot resolve, we create a shell season so the episode is not lost
                     logger.warning(f"[CR_MDNX_API] Season not resolved by number or name in line: {line}")
                     mapped_num = len(tmp_dict[current_series_id]["seasons"]) + 1
                     season_key = f"S{mapped_num}"
@@ -224,14 +230,14 @@ class CR_MDNX_API:
                         }
                         episode_counters[season_key] = 1
 
-                    # stabilize future matches for this season (by number and by name)
+                    # we stabilize future matches by updating maps from what we can infer here
                     season_num = re.search(r'- Season (\d+) -', line)
                     if season_num:
                         orig_label = int(season_num.group(1))
                         season_num_map.setdefault(orig_label, mapped_num)
                     name_to_season_key[sanitize(season_name_guess).lower()] = season_key
 
-                # ensure counter exists even if season header never appeared
+                # make sure the per-season counter exists even if there was no header
                 if season_key not in episode_counters:
                     episode_counters[season_key] = 1
 
@@ -240,8 +246,9 @@ class CR_MDNX_API:
                 ep_key = f"E{idx}"
                 episode_number_clean = str(idx)
                 episode_counters[season_key] += 1
-                episode_number_download = episode_number_clean
+                episode_number_download = episode_number_clean  # we keep download numbering aligned with clean numbering
 
+                # extract a clean episode title from the tail after the last " - "
                 parts = ep_info["full_episode_name"].rsplit(" - ", 1)
                 if len(parts) > 1:
                     episode_title_clean = parts[-1]
@@ -249,7 +256,7 @@ class CR_MDNX_API:
                     episode_title_clean = ep_info["full_episode_name"]
                 episode_title_clean = sanitize(episode_title_clean)
 
-                # stage the episode for committing when we see the next episode or at the end
+                # stage the episode so we can attach dubs and subs from following lines
                 active_season_key = season_key
                 active_episode_key = ep_key
                 staged_episode = {
@@ -265,14 +272,15 @@ class CR_MDNX_API:
                 logger.debug(f"[CR_MDNX_API] Staged new episode {current_series_id}/{season_key}/{ep_key}: '{episode_title_clean}'")
                 continue
 
-            # Check for versions (dubs) line.
+            # versions line like "- Versions: en, es-419, ..."
             match = self.versions_pattern.match(line)
             if match and current_series_id and active_season_key and active_episode_key and staged_episode and staged_episode.get("ep_key") == active_episode_key:
                 raw_list = match.group(1)
 
+                # we normalize entries and map human readable names to language codes
                 dub_codes = []
                 for lang in raw_list.split(','):
-                    lang = lang.strip().lstrip('☆').strip()
+                    lang = lang.strip().lstrip('☆').strip()  # strip the star marker the tool uses to indicate premium dubs
                     if lang in NAME_TO_CODE:
                         dub_codes.append(NAME_TO_CODE[lang])
 
@@ -280,7 +288,7 @@ class CR_MDNX_API:
                 logger.debug(f"[CR_MDNX_API] Staged episode-level dubs for {current_series_id}/{active_season_key}/{active_episode_key}: {dub_codes}")
                 continue
 
-            # Check for subtitles line.
+            # subtitles line like "- Subtitles: en-US, es-ES, ..."
             match = self.subtitles_pattern.match(line)
             if match and current_series_id and active_season_key and active_episode_key and staged_episode and staged_episode.get("ep_key") == active_episode_key:
                 raw_list = match.group(1).strip()
@@ -292,7 +300,7 @@ class CR_MDNX_API:
                         if token in VALID_LOCALES:
                             subs_locales.append(token)
                             continue
-                        # fallback to base language (e.g. en-US -> en) if base is valid
+                        # fallback to base language if regioned code is not in VALID_LOCALES
                         base = token.split('-', 1)[0]
                         if base in VALID_LOCALES:
                             subs_locales.append(base)
@@ -301,21 +309,19 @@ class CR_MDNX_API:
                 logger.debug(f"[CR_MDNX_API] Staged episode-level subtitles for {current_series_id}/{active_season_key}/{active_episode_key}: {subs_locales}")
                 continue
 
-        # Commit any trailing staged episode after the loop ends.
+        # commit any trailing staged episode once the loop ends
         _commit_staged()
 
-        # Remove seasons that ended up empty and reorder them.
-        # So, if there were 3 seasons, but only S1 and S3 had episodes,
-        # we would end up with S1 and S2, not S1 and S3.
+        # we remove empty seasons and renumber contiguous S1..SX to keep structure compact
         for series_id, series_info in tmp_dict.items():
             seasons = series_info["seasons"]
 
             kept_seasons = []
             for key, val in seasons.items():
-                if val["episodes"]:  # keep seasons that have at least one episode
+                if val["episodes"]:
                     kept_seasons.append((key, val))
 
-            # sort kept_seasons by the original season_number (as integers)
+            # sort seasons by their current mapped number so renumbering is stable
             kept_seasons.sort(key=lambda item: int(item[1]["season_number"]))
 
             new_seasons = {}

--- a/app/appdata/modules/HIDIVE_MDNX_API.py
+++ b/app/appdata/modules/HIDIVE_MDNX_API.py
@@ -346,7 +346,6 @@ class HIDIVE_MDNX_API:
             queue_manager.add(tmp_dict, self.queue_service)
         return tmp_dict
 
-
     def _probe_episode_streams(self, series_id: str, season_id: str, episode_index: int):
         logger.info(f"[HIDIVE_MDNX_API] Probing streams for series {series_id} season {season_id} episode {episode_index}...")
 

--- a/app/appdata/modules/HIDIVE_MDNX_API.py
+++ b/app/appdata/modules/HIDIVE_MDNX_API.py
@@ -107,8 +107,8 @@ class HIDIVE_MDNX_API:
         return None
 
     def process_console_output(self, output: str, add2queue: bool = True):
-
         def _group_matches(count_group: int, count_declared: int) -> bool:
+            # allow small mismatch between flat group size and declared eps to pick a best-fit map
             return abs(count_group - count_declared) <= 2
 
         logger.debug("[HIDIVE_MDNX_API] Processing console output...")
@@ -116,10 +116,10 @@ class HIDIVE_MDNX_API:
         current_series_id = None
         current_season_key = None
 
-        seasons_meta = {}
-        episodes_by_season = {}
+        seasons_meta = {}          # season_key -> parsed season metadata
+        episodes_by_season = {}    # season_key -> list of (episode_id, title)
 
-        flat_groups = []
+        flat_groups = []           # list of {"season_code": int, "map": {local_idx -> download_number}}
         current_flat_main_code = None
         current_group_local_index = 0
         skip_current_season = False
@@ -129,11 +129,13 @@ class HIDIVE_MDNX_API:
             if not line:
                 continue
             if line.startswith("[ERROR]") or line.startswith("[WARN]"):
+                # ignore tool diagnostics printed in the stream
                 continue
 
             # Series
             series_match = self.series_pattern.match(line)
             if series_match:
+                # start a new series and reset per-series state
                 gd = series_match.groupdict()
                 current_series_id = gd["series_id"]
                 tmp_dict[current_series_id] = {
@@ -154,6 +156,7 @@ class HIDIVE_MDNX_API:
                 continue
 
             if not current_series_id:
+                # ignore noise before the first series header
                 continue
 
             # Season (normal/special)
@@ -162,6 +165,7 @@ class HIDIVE_MDNX_API:
             season_any_special_match = self.season_any_special_pattern.match(line)
 
             if season_any_special_match or season_main_match or season_special_match:
+                # normalize the 3 season shapes into a single set of fields
                 if season_any_special_match:
                     gd = season_any_special_match.groupdict()
                     season_number = int(gd.get("season_number") or 0)
@@ -183,9 +187,11 @@ class HIDIVE_MDNX_API:
                 skip_current_season = season_is_special
 
                 if skip_current_season:
+                    # drop special seasons like OVA, Recap, Movie
                     logger.debug(f"[HIDIVE_MDNX_API] Skipping special season [{gd['season_id']}] '{label_text}' (S{season_number}).")
                     continue
 
+                # keep normal season metadata and init episode list
                 current_season_key = season_key
                 seasons_meta[season_key] = {
                     "season_id": gd["season_id"],
@@ -196,37 +202,43 @@ class HIDIVE_MDNX_API:
                 episodes_by_season.setdefault(season_key, [])
                 continue
 
-            # Episodes under current season
+            # Episodes under current season (hierarchical section)
             if current_season_key and not skip_current_season:
                 episode_match = self.episode_pattern.match(line)
                 if episode_match:
+                    # append raw episode rows; stream info is probed later
                     gd = episode_match.groupdict()
                     episodes_by_season[current_season_key].append(
                         (gd["episode_id"], gd["episode_title"])
                     )
                     continue
 
-            # Flat list rows
+            # Flat list rows like "[S01 E03] Title"
             flat_match = self.flat_episode_pattern.match(line)
             if flat_match:
                 gd = flat_match.groupdict()
                 season_code_raw = int(gd['season_code'])
                 download_str = gd["download_number"]
-                # skip fractional episodes like 7.5 (usually recap/special)
+
+                # skip fractional entries like 7.5 which are usually recaps or extras
                 if '.' in download_str:
                     logger.debug(f"[HIDIVE_MDNX_API] Skipping fractional flat episode E{download_str} (treated as special).")
                     continue
+
                 episode_download_number = int(download_str)
 
+                # start a new flat group when season code changes
                 if season_code_raw != current_flat_main_code:
                     current_flat_main_code = season_code_raw
                     flat_groups.append({"season_code": season_code_raw, "map": {}})
                     current_group_local_index = 0
 
+                # record mapping from tree index to download index
                 current_group_local_index += 1
                 flat_groups[-1]["map"][current_group_local_index] = episode_download_number
                 continue
 
+        # if we never saw a series header, return an empty result
         if not current_series_id:
             logger.warning("[HIDIVE_MDNX_API] No HiDive series detected in output.")
             if add2queue:
@@ -234,9 +246,10 @@ class HIDIVE_MDNX_API:
             return tmp_dict
 
         total_episodes = 0
+        # enforce S1..SX order for seasons we kept
         ordered_seasons = sorted(seasons_meta.items(), key=lambda kv: int(kv[1]["season_number"]))
 
-        flat_ptr = 0
+        flat_ptr = 0  # pointer into flat_groups
 
         for _season_idx, (season_key, meta) in enumerate(ordered_seasons, start=1):
             season_id = meta["season_id"]
@@ -244,7 +257,7 @@ class HIDIVE_MDNX_API:
             episode_list = episodes_by_season.get(season_key, [])
             declared_count = int(meta.get("eps_count") or 0)
 
-            # pick a flat map for this season
+            # pick a flat map whose season_code matches this season number
             download_map = {}
             i = flat_ptr
             while i < len(flat_groups):
@@ -255,7 +268,7 @@ class HIDIVE_MDNX_API:
                     break
                 i += 1
 
-            # fallback: accept next candidate within tolerance
+            # fallback: accept the next group with size close to declared count
             if not download_map:
                 while flat_ptr < len(flat_groups):
                     cand = flat_groups[flat_ptr]
@@ -266,9 +279,10 @@ class HIDIVE_MDNX_API:
                     flat_ptr += 1
 
             if not download_map:
+                # fall back to sequential download numbering later
                 logger.debug(f"[HIDIVE_MDNX_API] No flat map matched for {season_key}; falling back to 1..N.")
 
-            # Build a sequential list of download numbers from the flat map
+            # produce a list of download indices in tree order
             if download_map:
                 flat_order = [download_map[k] for k in sorted(download_map.keys())]
             else:
@@ -278,26 +292,28 @@ class HIDIVE_MDNX_API:
             filtered_episode_rows = []
 
             for local_tree_index, (episode_id, title) in enumerate(episode_list, start=1):
-                # Skip specials and unreleased
+                # drop unreleased and special episodes based on title cues
                 if title and (self.special_episode_title_flag.search(title) or self.unreleased_title_flag.search(title)):
                     logger.debug(f"[HIDIVE_MDNX_API] Skipping unavailable/special at {season_key} idx={local_tree_index} title='{title}'.")
                     continue
 
-                # Pull the next download number only for kept episodes
+                # choose the download number from flat mapping if available
                 if flat_idx < len(flat_order):
                     download_num = flat_order[flat_idx]
                     flat_idx += 1
                 else:
-                    # No flat numbers left. fall back to sequential numbering of kept episodes
+                    # otherwise assign sequentially among kept episodes
                     download_num = flat_idx + 1
                     flat_idx += 1
 
                 filtered_episode_rows.append((local_tree_index, episode_id, title, download_num))
 
+            # build the final episodes dict and probe stream languages for each kept episode
             episodes_dict = {}
             for local_index, (_, _episode_id, title, download_num) in enumerate(filtered_episode_rows, start=1):
                 dubs_list, subs_list = self._probe_episode_streams(series_id=current_series_id, season_id=season_id, episode_index=download_num)
 
+                # dedupe because probes can repeat values across lines
                 dubs_list = dedupe_casefold(dubs_list)
                 subs_list = dedupe_casefold(subs_list)
 
@@ -312,6 +328,7 @@ class HIDIVE_MDNX_API:
                 }
                 total_episodes += 1
 
+            # attach the season to the output
             tmp_dict[current_series_id]["seasons"][season_key] = {
                 "season_id": season_id,
                 "season_name": sanitize(meta["season_name"]),
@@ -320,59 +337,72 @@ class HIDIVE_MDNX_API:
                 "eps_count": str(len(episodes_dict))
             }
 
+        # fill in total ep count on series metadata
         tmp_dict[current_series_id]["series"]["eps_count"] = str(total_episodes)
 
         logger.debug("[HIDIVE_MDNX_API] Console output processed.")
         if add2queue:
+            # push the parsed result to the queue for downstream consumers
             queue_manager.add(tmp_dict, self.queue_service)
         return tmp_dict
+
 
     def _probe_episode_streams(self, series_id: str, season_id: str, episode_index: int):
         logger.info(f"[HIDIVE_MDNX_API] Probing streams for series {series_id} season {season_id} episode {episode_index}...")
 
+        # "--dubLang und" returns the available dubs/subs without actually downloading the episode
         cmd = [self.mdnx_path, "--service", self.mdnx_service, "--srz", str(series_id), "-s", str(season_id), "-e", str(episode_index), "--dubLang", "und"]
 
         logger.debug(f"[HIDIVE_MDNX_API] Probing streams: {' '.join(cmd)}")
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
+            # combine streams because MDNX sometimes prints headers on stderr
             combined_text = (result.stdout or "") + "\n" + (result.stderr or "")
             logger.debug(f"[HIDIVE_MDNX_API] Probe output:\n{combined_text}")
         except Exception as exc:
+            # if the probe fails we return empty lists so the caller can decide how to proceed
             logger.error(f"[HIDIVE_MDNX_API] Probe failed (series {series_id} season {season_id} episode {episode_index}): {exc}")
             return [], []
 
-        available_dubs = []
-        available_subs = []
-        in_audios = False
+        available_dubs = []  # collected normalized audio codes like "eng", "jpn"
+        available_subs = []  # collected normalized subtitle locales like "en", "pt-BR"
+        in_audios = False    # simple state machine to read multi-line sections
         in_subs = False
 
         for raw_line in combined_text.splitlines():
             line = raw_line.strip()
+
             if not line:
+                # blank lines end any active section block
                 in_audios = False
                 in_subs = False
                 continue
 
+            # header like "Audio: English, Japanese"
             if self.audio_header.search(raw_line):
                 in_audios, in_subs = True, False
+                # parse tokens on the same header line, if present
                 tail = self.audio_header.split(raw_line, 1)[-1].strip()
                 if tail:
                     for token in self._clean_tokens(tail):
-                        code = self._norm_audio(token)
+                        code = self._norm_audio(token)  # map display name or code to canonical audio code
                         if code:
                             available_dubs.append(code)
                 continue
 
+            # header like "Subs: EN, PT-BR"
             if self.subs_header.search(raw_line):
                 in_audios, in_subs = False, True
+                # parse tokens on the same header line, if present
                 tail = self.subs_header.split(raw_line, 1)[-1].strip()
                 if tail:
                     for token in self._clean_tokens(tail):
-                        loc = self._norm_sub(token)
+                        loc = self._norm_sub(token)  # map display name or code to canonical locale
                         if loc:
                             available_subs.append(loc)
                 continue
 
+            # continuation lines under the Audio section
             if in_audios and line:
                 for token in self._clean_tokens(line):
                     code = self._norm_audio(token)
@@ -380,6 +410,7 @@ class HIDIVE_MDNX_API:
                         available_dubs.append(code)
                 continue
 
+            # continuation lines under the Subs section
             if in_subs and line:
                 for token in self._clean_tokens(line):
                     loc = self._norm_sub(token)
@@ -387,6 +418,7 @@ class HIDIVE_MDNX_API:
                         available_subs.append(loc)
                 continue
 
+        # remove duplicates while preserving case-insensitive uniqueness
         dubs_deduped = dedupe_casefold(available_dubs)
         subs_deduped = dedupe_casefold(available_subs)
 


### PR DESCRIPTION
This fixes the parser putting S02E01 of "tales of wedding rings" in S01E13 because the output had this line:
```
[E13] [2025-10-04] Tales of Wedding Rings Season 2 - Season 1 - Episode 1
```
Because of that extra "Season 1" in there, it wouldn't increment the season number, putting the episode in the wrong place.

Also added more comments to better help future me haha